### PR TITLE
Require stdlib-shims

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -1,7 +1,7 @@
 (library
  (name fmt)
  (public_name fmt)
- (libraries result)
+ (libraries result stdlib-shims)
  (modules fmt)
  (flags :standard -w -3-6-27-34-50)
  (wrapped false))

--- a/src/dune
+++ b/src/dune
@@ -1,7 +1,7 @@
 (library
  (name fmt)
  (public_name fmt)
- (libraries result stdlib-shims)
+ (libraries result seq stdlib-shims)
  (modules fmt)
  (flags :standard -w -3-6-27-34-50)
  (wrapped false))


### PR DESCRIPTION
[   50s] Command [9] exited with code 2:
[   50s] $ (cd _build/default && /usr/bin/ocamlc.opt -w -40 -w -3-6-27-34-50 -g -bin-annot -I src/.fmt.objs/byte -I /usr/lib64/ocaml/result -no-alias-deps -o src/.fmt.objs/byte/fmt.cmi -c -intf src/fmt.mli)
[   50s] File "src/fmt.mli", line 27, characters 58-71:
[   50s] Error: Unbound module Stdlib

Signed-off-by: Olaf Hering <olaf@aepfle.de>